### PR TITLE
Set up towncrier for markdown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,10 @@
 
 ## 0.1.0 (2022-07-03)
 
-### New Features
+### 🍰 New Features
 
 - Added the logize package for creating official CSDMS text-based logos. ([#1](https://github.com/mcflugen/logoizer/issues/1))
 
-### Other Changes and Additions
+### 🔩 Other Changes and Additions
 
 - Changed the name of the project from *logoize* to *logoizer*. ([#2](https://github.com/mcflugen/logoizer/issues/2))

--- a/news/4.misc
+++ b/news/4.misc
@@ -1,0 +1,1 @@
+Updated the linters and added several new ones.

--- a/news/5.misc
+++ b/news/5.misc
@@ -1,0 +1,1 @@
+Removed dependency on *click* (and *rich_click*) by moving to *argparse*.

--- a/news/6.docs
+++ b/news/6.docs
@@ -1,0 +1,1 @@
+Converted the docs from ReStructuredText to markdown.

--- a/news/7.docs
+++ b/news/7.docs
@@ -1,0 +1,1 @@
+Modified towncrier to work with markdown rather than ReStructuredTxt.

--- a/news/changelog_template.jinja
+++ b/news/changelog_template.jinja
@@ -1,0 +1,15 @@
+{% if sections[""] %}
+{% for category, val in definitions.items() if category in sections[""] %}
+
+### {{ definitions[category]['name'] }}
+
+{% for text, values in sections[""][category].items() %}
+- {{ text }} {{ values|join(', ') }}
+{% endfor %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+
+{% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,32 +110,26 @@ force_grid_wrap = 0
 combine_as_imports = true
 line_length = 88
 
-
 [tool.towncrier]
 directory = "news"
-package = "logoizer"
+name = "logoizer"
 filename = "CHANGES.md"
+create_add_extension = false
 single_file = true
-underlines = "-`^"
-issue_format = "`#{issue} <https://github.com/mcflugen/logoizer/issues/{issue}>`_"
-title_format = "{version} ({project_date})"
-
-[[tool.towncrier.type]]
-directory = "feature"
-name = "New Features"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "bugfix"
-name = "Bug Fixes"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "docs"
-name = "Documentation Enhancements"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "misc"
-name = "Other Changes and Additions"
-showcontent = true
+underlines = [
+    "",
+    "",
+    "",
+]
+start_string = """
+<!-- towncrier release notes start -->
+"""
+template = "news/changelog_template.jinja"
+issue_format = "[#{issue}](https://github.com/mcflugen/logoizer/issues/{issue})"
+title_format = "## {version} ({project_date})"
+type = [
+  {name="🍰 New Features", directory="feature", showcontent=true},
+  {name="🛠️ Bug Fixes", directory="bugfix", showcontent=true},
+  {name="📖 Documentation Enhancements", directory="docs", showcontent=true},
+  {name="🔩 Other Changes and Additions", directory="misc", showcontent=true},
+]


### PR DESCRIPTION
This pull request adjust *towncrier* to use *markdown* files rather than *rst*.